### PR TITLE
Update Readme with More Explicit Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ Generate [RxJS](https://github.com/Reactive-Extensions/RxJS) docset for [Dash](h
 Make sure you have `node`, `bower` on your system.
 
 ```
-$ git clone riiid/rxjs-dash --recursive
+$ git clone https://github.com/riiid/rxjs-dash.git --recursive
 $ cd rxjs-dash
 $ npm start
+$ mkdir ~/Library/Application\ Support/Dash/DocSets/RxJs
+$ mv rxjs.docset ~/Library/Application\ Support/Dash/DocSets/RxJs/
 ```
 
 add `rxjs.docset` to `Dash`


### PR DESCRIPTION
1. I changed the git clone url to include the complete url. I recieved this error,  'fatal: repository 'riiid/rxjs-dash' does not exist'.
2. I also included the steps needed to add docset to dash.