### PR TITLE
Add missing bower module `primer-markdown`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Generate [RxJS](https://github.com/Reactive-Extensions/RxJS) docset for [Dash](h
 
 ## Generate docset
 
-Make sure you have `node`, `bower` on your system.
+Make sure you have `node` on your system.
 
 ```
 $ git clone https://github.com/riiid/rxjs-dash.git --recursive

--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "primer-css": "~2.3.3"
+    "primer-css": "~2.3.3",
+    "primer-markdown": "~2.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "generate rxjs docset for dash",
   "main": "docset.coffee",
   "dependencies": {
+    "bower": "^1.6.5",
     "cheerio": "^0.19.0",
+    "coffee-script": "^1.10.0",
     "fs-extra": "^0.24.0",
     "glob": "^5.0.14",
     "highlight.js": "^8.7.0",


### PR DESCRIPTION
The bower module `primer-markdown`has been added to the `bower.json` file to fix the error...
```bash
Error: ENOENT: no such file or directory, lstat 'bower_components/primer-markdown/dist/user-content.css'
  at Error (native)
```
...encountered when `coffee docset.coffee` is executed.